### PR TITLE
Handle empty arguments

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -26,7 +26,7 @@ func SplitBatch(line string) ([]string, error) {
 // QuoteBatch returns the string such that a CMD.EXE shell would parse it as a single word
 func QuoteBatch(s string) string {
 	var builder strings.Builder
-	var needsQuotes bool
+	var needsQuotes = len(s) == 0 // Ensure empty argument is quoted
 
 	for _, c := range s {
 		if strings.ContainsRune(batchSpecialChars, c) {

--- a/batch_test.go
+++ b/batch_test.go
@@ -52,6 +52,19 @@ func TestSplitBatch(t *testing.T) {
 				`^^&`,
 			},
 		},
+		{
+			`simple ""`, []string{
+				`simple`,
+				``,
+			},
+		},
+		{
+			`simple "" "abc" `, []string{
+				`simple`,
+				``,
+				`abc`,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -81,6 +94,7 @@ func TestQuoteBatch(t *testing.T) {
 		{`this has spaces`, `"this has spaces"`},
 		{`this has $pace$`, `"this has $pace$"`},
 		{`this has %spaces%`, `"this has ^%spaces^%"`},
+		{``, `""`},
 	}
 
 	for _, tc := range testCases {

--- a/parser.go
+++ b/parser.go
@@ -36,6 +36,7 @@ type parser struct {
 func (p *parser) Parse() ([]string, error) {
 	var words = []string{}
 	var word strings.Builder
+	var token = false // Used to force token emission, even if empty
 
 	for {
 		// Read until we encounter a delimiter character
@@ -61,6 +62,8 @@ func (p *parser) Parse() ([]string, error) {
 				return nil, err
 			}
 
+			token = true // Ensure a token will be emitted, even if empty (e.g. "")
+
 			// Write to the buffer
 			word.WriteString(quote)
 
@@ -73,9 +76,10 @@ func (p *parser) Parse() ([]string, error) {
 
 		// Handle field seperators
 		case p.isFieldSeperator(r):
-			if word.Len() > 0 {
+			if word.Len() > 0 || token {
 				words = append(words, word.String())
 				word.Reset()
+				token = false
 			}
 
 		default:
@@ -83,7 +87,7 @@ func (p *parser) Parse() ([]string, error) {
 		}
 	}
 
-	if word.Len() > 0 {
+	if word.Len() > 0 || token {
 		words = append(words, word.String())
 		word.Reset()
 	}

--- a/posix.go
+++ b/posix.go
@@ -25,7 +25,7 @@ func SplitPosix(line string) ([]string, error) {
 // QuotePosix returns the string such that a posix shell would parse it as a single word
 func QuotePosix(s string) string {
 	var builder strings.Builder
-	var needsQuotes bool
+	var needsQuotes = len(s) == 0 // Ensure empty argument is quoted
 
 	for _, c := range s {
 		if strings.ContainsRune(posixSpecialChars, c) {


### PR DESCRIPTION
These changes fix an issue where parsing quoted empty arguments cause them to be omitted.

For example, in both posix and windows cmd, parsing `foo "" bar` should return three tokens, not two.

I have confirmed that similar libraries (e.g. https://github.com/kballard/go-shellquote and https://github.com/google/shlex) do handle empty arguments, and these changes bring shellwords closer to the behaviour those libraries.

I included symmetrical handling for quoting, and an empty input will now emit `""`. Note that kballard/go-shellquote emits `''` in this case, but I think the important thing is that `split(quote(x)) = x`, which is essentially true with these changes (if quote took an arary, etc.).