### PR TITLE
Relax go version requirement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/buildkite/shellwords
 
-go 1.24.3
+go 1.24.0


### PR DESCRIPTION
Relax go version requirement.
This way dependents of this module will be able to build their binaries with older go versions. 