### PR TITLE
Relax go directive to permit 1.24.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/buildkite/shellwords
 
-go 1.24.3
+go 1.24.0


### PR DESCRIPTION
Setting this to 1.24.3 requires all consumers to be building with 1.24.3 or newer release of Go 1.24 and to update their own go.mod accordingly. This is unnecessarily restrictive - the go directive should be the minimum version necessary for the Go features used by the module, with consumers using the latest Go version when building.

With this fix, we can also update the go directive in buildkite/agent to 1.24.0, and further update dependents of buildkite/agent (for my use case, this is sigstore/cosign).