### PR TITLE
Relax go version requirement to go1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/buildkite/shellwords
 
-go 1.24.3
+go 1.22


### PR DESCRIPTION
closes #3 

We don't actually use any go 1.24 features, so we can relax the version requirement further. We do need go 1.22 though, as we removed a bunch of loop var captures (mostly in tests) in #2.

thanks @vpnachev for reporting!